### PR TITLE
75 consolelogsasgraphs fails to identify root node when input filename and sequence count match a downstream output

### DIFF
--- a/R/file_size.R
+++ b/R/file_size.R
@@ -232,7 +232,7 @@ formatConsoleLog <- function(log_file){
             log_table[['input_size']] <- NA
         }
     }
-    log_table[['task']] <- task
+    log_table[['task']] <- as.character(task)
     log_table[['input_size']] <- as.numeric(log_table[['input_size']])
     log_table[['output_size']] <- as.numeric(log_table[['output_size']])
     log_table %>%

--- a/R/file_size.R
+++ b/R/file_size.R
@@ -327,7 +327,69 @@ consoleLogsAsGraphs <- function(logs, metadata=NULL) {
                                    rename(name=input_id),
                                directed = TRUE,
                                vertices = vertex_meta)
-    
+
+    # We found situations where a file from an earlier pipeline stage and a file
+    # produced by a later step have the same name AND the same number of sequences
+    # (e.g. the original HCD_3_db-pass.tsv used as input to RenameFile, and the
+    # HCD_3_db-pass.tsv produced by MakeDB when no sequences were lost before that
+    # step). Both get the same vertex ID (paste(filename, size)), which creates a
+    # cycle in the graph and prevents the root node from being identified.
+    #
+    # Fix: find the vertex that sits at the "exit" of the cycle -- it has an
+    # in-edge from within the cycle (produced by e.g. MakeDB) and an out-edge
+    # escaping it (consumed by e.g. FilterQuality). Create a new root node with
+    # the same filename/size and redirect the cycle-bound out-edges to it.
+    # Repeat until the graph is a DAG.
+    while (!igraph::is_dag(g)) {
+        scc       <- igraph::components(g, mode = "strong")
+        cycle_ids <- which(scc$csize > 1)
+        if (length(cycle_ids) == 0) break
+
+        scc_id    <- cycle_ids[1]
+        scc_verts <- which(scc$membership == scc_id)
+
+        split_v <- NA_integer_
+        for (v in scc_verts) {
+            in_v  <- as.integer(igraph::neighbors(g, v, mode = "in"))
+            out_v <- as.integer(igraph::neighbors(g, v, mode = "out"))
+            if (any(in_v %in% scc_verts) && any(!(out_v %in% scc_verts))) {
+                split_v <- v
+                break
+            }
+        }
+        if (is.na(split_v)) {
+            warning("Could not resolve cycle in log graph; check that log files are correct.")
+            break
+        }
+
+        v_filename <- V(g)$filename[split_v]
+        v_num_seqs <- V(g)$num_seqs[split_v]
+        root_name  <- paste0(V(g)$name[split_v], "_root")
+        warning("Cycle detected: '", v_filename, "' appears with the same name and ",
+                "sequence count at different pipeline stages (e.g. original input vs ",
+                "MakeDB output). A root node '", root_name,
+                "' has been created for the original input file.")
+
+        # Out-edges of split_v that go to other SCC members: move them to the root node
+        out_edges <- as.integer(igraph::incident(g, split_v, mode = "out"))
+        out_to    <- matrix(igraph::ends(g, out_edges, names = FALSE), ncol = 2)[, 2]
+        scc_mask  <- out_to %in% scc_verts
+        scc_out_e <- out_edges[scc_mask]
+
+        g <- igraph::add_vertices(g, 1,
+                                  name     = root_name,
+                                  filename = v_filename,
+                                  num_seqs = v_num_seqs)
+        root_idx <- igraph::vcount(g)
+
+        for (e_id in scc_out_e) {
+            to_v   <- igraph::ends(g, e_id, names = FALSE)[1, 2]
+            e_task <- igraph::E(g)$task[e_id]
+            g <- igraph::add_edges(g, c(root_idx, to_v), task = e_task)
+        }
+        g <- igraph::delete_edges(g, scc_out_e)
+    }
+
     # Identify graph components, belonging to the different
     # groups of files that belong to the same original data
     # source

--- a/inst/rstudio/templates/project/file_size_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/file_size_project_files/index.Rmd
@@ -164,14 +164,14 @@ for (i in order(ids)) {
                    file=out_filename)
     
     p <- ggplot(plot_table, 
-           aes(x=filename, y=num_seqs, group=name)) +
+           aes(x=name, y=num_seqs, group=name)) +
         geom_bar(stat="identity") +
+        scale_x_discrete(labels=setNames(plot_table$filename, plot_table$name)) +
         theme_enchantr() +
         theme(
             axis.text.x = element_text(angle = 90, hjust=0.5, vjust=0)
         ) +
-        labs(x="File", y="Number of sequences") # +
-        # scale_x_discrete(labels= function(x) { gsub("(.*_)([^_]*$)","\\2",x)} ) # Do we need this for shorter x-axis labels?
+        labs(x="File", y="Number of sequences")
         
     cat(tab$caption)
     # Remove file extension safely

--- a/inst/rstudio/templates/project/file_size_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/file_size_project_files/index.Rmd
@@ -130,7 +130,7 @@ cat("\n\n")
 ```{r, results="asis", echo=FALSE, fig.width=8,fig.height=6}
 ids <- names(log_data_graphs$by_sample)
 for (i in order(ids)) {
-    this_id <- ids[i]
+    this_id <- sub("_root$","",ids[i])
     
     log_plot <- plotLogGraph(log_data_graphs$by_sample[[i]])
     

--- a/tests/testthat/test_file-size.R
+++ b/tests/testthat/test_file-size.R
@@ -46,7 +46,7 @@ test_that("file size report issue 49", {
     expeted_log <- data.frame(
             input = c("Sample8_quality-pass.tsv", "Sample8_quality-pass.tsv"), 
             output = c("Sample8_productive-F.tsv", "Sample8_productive-T.tsv"),
-            task = structure(c(1L, 1L), class = "factor", levels = "ParseDb-split"), 
+            task = c("ParseDb-split", "ParseDb-split"), 
             input_size = c(92, 92), 
             output_size = c(3, 89))
     expect_equal(out_log, expeted_log)

--- a/tests/testthat/test_file-size.R
+++ b/tests/testthat/test_file-size.R
@@ -78,3 +78,39 @@ test_that("makedb igblast parses OUTPUT>", {
     expect_equivalent(as.matrix(out_log), as.matrix(expected_log))
     
 })
+
+test_that("consoleLogsAsGraphs handles same filename+size at different pipeline stages (cycle bug)", {
+    # HCD_3_db-pass.tsv exists both as the original pipeline input (root) and
+    # as the output of MakeDB-igblast, with identical filenames and sequence counts.
+    # The node ID paste(filename, size) collapses both into one vertex, creating a
+    # cycle: HCD_3_db-pass.tsv -> RenameFile -> ... -> MakeDB -> HCD_3_db-pass.tsv
+    # The fix splits the collision vertex into a "root" node (original file) and the
+    # produced node (MakeDB output), resulting in a valid DAG.
+    logs <- data.frame(
+        log_id     = paste0("log_", 1:5),
+        input      = c("HCD_3_db-pass.tsv",     # RenameFile: original file -> HCD_3.tsv
+                       "HCD_3.tsv",              # ConvertDb
+                       "HCD_3_sequences.fasta",  # AssignGenes
+                       "HCD_3_igblast.fmt7",     # MakeDB: produces HCD_3_db-pass.tsv again
+                       "HCD_3_db-pass.tsv"),     # FilterQuality: consumes MakeDB output
+        output     = c("HCD_3.tsv",
+                       "HCD_3_sequences.fasta",
+                       "HCD_3_igblast.fmt7",
+                       "HCD_3_db-pass.tsv",      # same name AND size as the root input
+                       "HCD_3_quality-pass.tsv"),
+        task       = c("RenameFile", "ConvertDb-fasta", "AssignGenes-igblast",
+                       "MakeDB-igblast", "FilterQuality"),
+        input_size  = c(100, 100, 100, 100, 100),
+        output_size = c(100, 100, 100, 100,  95),
+        stringsAsFactors = FALSE
+    )
+
+    result <- consoleLogsAsGraphs(logs, metadata = NULL)
+
+    # Graph must be a valid DAG (no cycles)
+    expect_true(igraph::is_dag(result$workflow))
+
+    # There must be at least one identifiable root node (in-degree 0)
+    root_count <- sum(igraph::degree(result$workflow, mode = "in") == 0)
+    expect_gte(root_count, 1)
+})


### PR DESCRIPTION
We found situations where a file from an earlier pipeline stage and a file produced by a later step have the same name and the same number of sequences (e.g. the original HCD_3_db-pass.tsv used as input to RenameFile, and the HCD_3_db-pass.tsv produced by MakeDB when no sequences were lost before that step). Both get the same vertex ID (paste(filename, size)), which creates a cycle in the graph and prevents the root node from being identified. Fix: find the vertex that sits at the "exit" of the cycle -- it has an in-edge from within the cycle (produced by e.g. MakeDB) and an out-edge escaping it (consumed by e.g. FilterQuality). Create a new root node with the same filename/size and redirect the cycle-bound out-edges to it. Repeat until the graph is a DAG.