### PR TITLE
Show proper message if no cell left after single cell qc

### DIFF
--- a/inst/rstudio/templates/project/single_cell_qc_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/single_cell_qc_project_files/index.Rmd
@@ -173,7 +173,7 @@ print_table_caption(tag = "seqs_per_cell", text = tab$caption)
 
 Since most of the analyses are based on heavy chains, we remove cells with only light chains.
 
-```{r findLightOnlyCells, results="asis"}
+```{r findLightOnlyCells, eval=nrow(db)>0, results="asis"}
 db <- findLightOnlyCells(db, sample_id = "sample_id", cell_id = "cell_id",
                          locus = "locus", fields = NULL)
 light_only_size <- sum(db[["light_only_cell"]])
@@ -198,6 +198,10 @@ tab <- eetable(light_only,
                caption = paste("Cells with only light chains account for",
                                light_only_size, caption_text_seq, "removed."))
 tab$table
+
+if(nrow(db)==0){
+  cat("\nNo cells left after removing cells without heavy chains.\n\n")
+}
 ```
 
 ```{r echo=FALSE, results="asis"}
@@ -210,35 +214,47 @@ When calling clones (B cells that descend from a common naive B cell ancestor) f
 
 A simple solution is just to remove cells with multiple heavy chains from the single cell data:
 
-```{r removeDoublets}
+```{r removeDoublets, eval=nrow(db)>0, results = 'asis'}
 db <- removeDoublets(db, cell_id = "cell_id", locus = "locus",
                      sequence_id = "sequence_id", fields = "sample_id")
 db_no_doublets_size <- nrow(db)
-```
 
-`r db_with_heavy_size-db_no_doublets_size` sequences have been removed because they were found in cells with multiple heavy chains.
+cat(paste(db_with_heavy_size-db_no_doublets_size, "sequences have been removed because they were found in cells with multiple heavy chains."))
+
+if(nrow(db)==0){
+  cat("No cells left after removing cells with multiple heavy chains.\n\n")
+}
+
+```
 
 # Check for contamination
 
 Sequences in different samples that share the same `cell_id` and nucleotide sequence (`sequence_alignment`) can indicate contamination.
 
-```{r eval= ! params$checkcontamination, results="asis"}
-cat("Skip checking for contamination as the parameter `checkcontamination` was set to `FALSE`.")
+```{r results="asis"}
+sample_count <- n_distinct(db$sample_id)
+
+if(!params$checkcontamination){
+  cat("Skip checking for contamination as the parameter `checkcontamination` was set to `FALSE`.")
+  calculate_contamination <- FALSE
+}else if(sample_count<=1){
+  cat("Contamination checking was skipped because the dataset did not have multiple samples left.")
+  calculate_contamination <- FALSE
+}else{
+  calculate_contamination <- TRUE
+}
 dups_found <- FALSE
 ```
 
-
-```{r sc-duplicates, eval=params$checkcontamination, results="asis"}
-# Find duplicated sequences
+```{r sc-duplicates, eval=calculate_contamination, results="asis"}
+## Find duplicated sequences
 dups <- findSingleCellDuplicates(db, fields = "sample_id", cell_id = "cell_id",
                                  seq = "sequence_alignment", mode = "sequences")
 dups_found <- sum(dups$dups$sc_duplicate, na.rm = T) > 0
 ```
 
-```{r sc-duplicates-zero, results="asis", eval= params$checkcontamination && !dups_found, echo=FALSE}
-if (nrow(dups[["dups"]]) == 0) {
-  cat("No suspicious overlaps detected.\n\n")
-}
+```{r sc-duplicates-zero, results="asis", eval=calculate_contamination && !dups_found, echo=FALSE}
+cat("No suspicious overlaps detected.\n\n")
 ```
 
 ```{r sc-duplicates-summary, results="asis", eval=dups_found}
@@ -287,9 +303,10 @@ tab_dups_summary$table %>%
 print_table_caption(tag = "dups_summary", text = tab_dups_summary$caption)
 ```
 
-## Stacked bar plot
-
 ```{r p-sc-duplicates, fig.cap=p_sc_duplicates$enchantr$html_caption, results="asis", eval=dups_found}
+
+cat("## Stacked bar plot")
+
 caption <- "Number of sequences that share cell_id and sequence with other samples."
 p_sc_duplicates <- ggplot(dups[["dups"]],
                           aes(x = sample_id, fill = sc_duplicate_cell)) +
@@ -303,9 +320,12 @@ p_sc_duplicates <- eeplot(p_sc_duplicates, params$outdir,
 ggplotly(p_sc_duplicates) %>% layout(barmode = "stack")
 ```
 
-## Cell overlaps matrix
 
-```{r overlap-summary, eval=dups_found}
+
+```{r overlap-summary, eval=dups_found, results="asis"}
+
+cat("## Cell overlaps matrix")
+
 # find the number of cells having same seq and cell barcode
 dup_count <- singleCellSharingCounts(dups)
 


### PR DESCRIPTION
Worked on enchantr issues 60
[#60](https://github.com/immcantation/enchantr/issues/60)
Display message "No cells left after removing cells without heavy chains." when there's no cell left after removing cells with only light chains.
Display message "No cells left after removing cells with multiple heavy chains." when there's no cell left after removing cells with multiple heavy chain.
Skip the following analyzing steps if no cell left to avoid error due to empty dataset.