### PR TITLE
Novel allele and genotype

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -2,6 +2,6 @@
 # Generator token: 10BE3573-1514-4C36-9D1C-5A225CD40393
 
 mutation_count <- function(germs, inputs, X = 0L, parallel = FALSE, return_count = FALSE) {
-    .Call('_enchantr_mutation_count', PACKAGE = 'enchantr', germs, inputs, X, parallel, return_count)
+    .Call(`_enchantr_mutation_count`, germs, inputs, X, parallel, return_count)
 }
 

--- a/inst/rstudio/templates/project/tigger_bayesian_genotype_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/tigger_bayesian_genotype_project_files/index.Rmd
@@ -604,8 +604,8 @@ cat(paste0("\nMETHOD> TIgGER Bayesian"), file = log_fn, append = TRUE)
 cat(paste0("\nFILE> ", basename(params$input)), file = log_fn, append = TRUE)
 cat(paste0("\nGENOTYPE_LOCI> ", paste0(loci, collapse = ",")), file = log_fn, append = TRUE)
 cat(paste0("\nGENOTYPE_SEGMENTS> ", paste0(segments_to_genotype, collapse = ",")), file = log_fn, append = TRUE)
-cat(paste0("\nOUTPUT> ", genotypes_output_dir), file = log_fn, append = TRUE)
-cat(paste0("\nOUTPUT_REFERENCE> ", file.path(params$outdir, "references")), file = log_fn, append = TRUE)
+cat(paste0("\nOUTPUT> ", basename(genotypes_output_dir)), file = log_fn, append = TRUE)
+cat(paste0("\nOUTPUT_REFERENCE> ", basename(file.path(params$outdir, "references"))), file = log_fn, append = TRUE)
 ```
 
 ```{r, child=c('versions.Rmd')}


### PR DESCRIPTION
Fix the issue in genotyping log file in which output file name containing full path that leads to the unmatched snapshots in nf-core/airrrflow test. 