### PR TITLE
18 update box example files

### DIFF
--- a/R/clonal_assignment.R
+++ b/R/clonal_assignment.R
@@ -457,13 +457,24 @@ plotDbOverlap <- function(db, group="sample",
     p <- p + ggtitle(title) +
         theme(plot.title = element_text(lineheight=.8, face="bold"))
     if (!silent) print(p)
+
+    # xlab/ylab may be identical (e.g. a single feature compared across
+    # group with itself), in which case Var1/Var2 can't both be renamed
+    # to the same name.
+    xcol <- xlab
+    ycol <- ylab
+    if (xcol == ycol) {
+        xcol <- paste0(xcol, ".1")
+        ycol <- paste0(ycol, ".2")
+    }
+
     invisible(list("p"=p,
                    "perc"=melt_overlap_perc %>%
-                       rename(!!rlang::sym(xlab) := Var1,
-                              !!rlang::sym(ylab) := Var2),
+                       rename(!!rlang::sym(xcol) := Var1,
+                              !!rlang::sym(ycol) := Var2),
                    "note"=melt_overlap_note %>%
-                       rename(!!rlang::sym(xlab) := Var1,
-                              !!rlang::sym(ylab) := Var2))
+                       rename(!!rlang::sym(xcol) := Var1,
+                              !!rlang::sym(ycol) := Var2))
     )
 }
 

--- a/inst/rstudio/templates/project/clonal_assignment_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/clonal_assignment_project_files/index.Rmd
@@ -12,10 +12,10 @@ link-citations: yes
 description: "enchantr clonal assignment"
 output: enchantr::immcantation
 params:
-   input: 
+   input:
       label: "`input`: Path to repertoires files"
       input: file
-      value: "https://yale.box.com/shared/static/dajikxtvbc3c5yw1o2v69fjtx5bh58r2.tsv"
+      value: "https://raw.githubusercontent.com/immcantation/enchantr/refs/heads/master/data-raw/example_data_subject1.tsv"
    imgt_db:
       label: "`imgt_db`: Path to IMGT reference  database."
       input: file
@@ -39,7 +39,7 @@ params:
    threshold:
       label: "`threshold`"
       input: numeric
-      value: 1
+      value: 0.2
    outputby:
       label: "`outputby` name of the column in `input` that contains sample identifiers that will be used to split the output db." 
       input: text

--- a/inst/rstudio/templates/project/convergence_project_files/convergence.Rmd
+++ b/inst/rstudio/templates/project/convergence_project_files/convergence.Rmd
@@ -47,25 +47,41 @@ if (sum(heavy_chains)>0) {
 
 ## Heatmap
 
-```{r overlap, eval="convergent_cluster_id" %in% colnames(db)}
-convergence_overlap <- plotDbOverlap(db %>% 
-                                         filter(isHeavyChain(locus)) %>%
-                                         rowwise() %>%
-                                         mutate(clone_id = paste(
-                                             unique(c(!!rlang::sym(params$cloneby), 
-                                                      clone_id)), collapse ="_")
-                                         ), 
-                                     group="sample_id", 
-                                     features=c("convergent_cluster_id","clone_id"), 
-                                     heatmap_colors=c("white","orange", "grey80"), 
-                                     print_zero=FALSE, long_x_angle=90,
-                                     title=NULL,xlab=NULL, ylab=NULL,
-                                     plot_order="sample_id", 
-                                     silent=T, similarity=c("min","min"),
-                                     na.rm=FALSE, 
-                                     identity=c('exact', 'exact'), 
-                                     threshold=0,
-                                     geom_text_size=3) 
+```{r overlap, eval="convergent_cluster_id" %in% colnames(db) }
+if ("clone_id" %in% colnames(db)) {
+    convergence_overlap <- plotDbOverlap(db %>% 
+                                             filter(isHeavyChain(locus)) %>%
+                                             rowwise() %>%
+                                             mutate(clone_id = paste(
+                                                 unique(c(!!rlang::sym(params$cloneby), 
+                                                          clone_id)), collapse ="_")
+                                             ), 
+                                         group="sample_id", 
+                                         features=c("convergent_cluster_id","clone_id"), 
+                                         heatmap_colors=c("white","orange", "grey80"), 
+                                         print_zero=FALSE, long_x_angle=90,
+                                         title=NULL,xlab=NULL, ylab=NULL,
+                                         plot_order="sample_id", 
+                                         silent=T, similarity=c("min","min"),
+                                         na.rm=FALSE, 
+                                         identity=c('exact', 'exact'), 
+                                         threshold=0,
+                                         geom_text_size=3)
+} else {
+    convergence_overlap <- plotDbOverlap(db %>% 
+                                             filter(isHeavyChain(locus)), 
+                                         group="sample_id", 
+                                         features=c("convergent_cluster_id"), 
+                                         heatmap_colors=c("white","orange", "grey80"), 
+                                         print_zero=FALSE, long_x_angle=90,
+                                         title=NULL,xlab=NULL, ylab=NULL,
+                                         plot_order="sample_id", 
+                                         silent=T, similarity=c("min"),
+                                         na.rm=FALSE, 
+                                         identity=c('exact'), 
+                                         threshold=0,
+                                         geom_text_size=3)   
+}
 ```
 
 ```{r overlapconvergenceplot, fig.width=min(10,max(5,0.5*length(unique(db[['sample_id']])))),  fig.height=min(50,max(5,0.5*length(unique(db[['sample_id']])))), fig.cap=caption, eval=exists("convergence_overlap")}
@@ -84,7 +100,7 @@ caption <- overlapconvergenceplot$enchantr$html_caption
 ```{r upset, results='asis', eval="convergent_cluster_id" %in% colnames(db)}
 # Add clone_size
 convergent_clone_sizes <- countClones(
-            db %>% filter(isHeavyChain(locus)) %>% select(-clone_id), # Keep heavy chains only
+            db %>% filter(isHeavyChain(locus)) %>% select(-any_of("clone_id")),
             groups="sample_id",
             clone = "convergent_cluster_id")
 upset_plot <- plotConvergenceUpSet(convergent_clone_sizes)

--- a/inst/rstudio/templates/project/convergence_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/convergence_project_files/index.Rmd
@@ -15,7 +15,7 @@ params:
    input: 
       label: "`input`: Path to repertoires files"
       input: file
-      value: "https://yale.box.com/shared/static/dajikxtvbc3c5yw1o2v69fjtx5bh58r2.tsv"
+      value: "https://raw.githubusercontent.com/immcantation/enchantr/refs/heads/master/data-raw/example_data_2subjects_clone-pass.tsv"
    imgt_db:
       label: "`imgt_db`: Path to IMGT reference  database."
       input: file

--- a/inst/rstudio/templates/project/dowser_lineage_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/dowser_lineage_project_files/index.Rmd
@@ -15,7 +15,7 @@ params:
    input:
       label: "`input`: Path to repertoires file"
       input: file
-      value: "https://yale.box.com/shared/static/tx1mg3u13nsz04sa9u7p3j1fg3he1f0v.tsv"
+      value: "https://raw.githubusercontent.com/immcantation/enchantr/refs/heads/master/data-raw/example_data_subject1_clone33.tsv"
    build:
        label: "`build`"
        input: text

--- a/inst/rstudio/templates/project/find_threshold_project_files/index.Rmd
+++ b/inst/rstudio/templates/project/find_threshold_project_files/index.Rmd
@@ -15,7 +15,7 @@ params:
    input: 
       label: "`input`: Path to repertoires file"
       input: file
-      value: "https://yale.box.com/shared/static/dajikxtvbc3c5yw1o2v69fjtx5bh58r2.tsv"
+      value: "https://raw.githubusercontent.com/immcantation/enchantr/refs/heads/master/data-raw/example_data_subject1.tsv"
    cloneby:
       label: "`cloneby`"
       input: text

--- a/tests/testthat/test_IO.R
+++ b/tests/testthat/test_IO.R
@@ -5,8 +5,17 @@ test_that("read input url", {
     url <- "https://zenodo.org/records/8179846/files/BCR_data_sample1.tsv"
     # TODO: expect no errors or warning once file in Zenodo updated
     # with rev_comp = FALSE
-    expect_warning(readInput(url), "rev_comp is not logical for row\\(s\\):")
-    #expect_no_error(readInput(url))
+    # Older airr versions warn that rev_comp is not logical; newer versions
+    # don't. Muffle the warning if it happens, but let any other (unexpected)
+    # warning propagate and fail the test.
+    withCallingHandlers(
+        readInput(url),
+        warning = function(w) {
+            if (grepl("rev_comp is not logical for row\\(s\\):", conditionMessage(w))) {
+                invokeRestart("muffleWarning")
+            }
+        }
+    )
     
     url <- "https://zenodo.org/records/8179846/files/BCR_data.tsv"
     expect_warning(readInput(url), "sequence_id\\(s\\) are not unique")

--- a/tests/testthat/test_clonal_assignment.R
+++ b/tests/testthat/test_clonal_assignment.R
@@ -1,22 +1,65 @@
 IMGT_URL <- "https://raw.githubusercontent.com/nf-core/test-datasets/airrflow/database-cache/imgtdb_base.zip"
 IMGT_DB <- prepareIMGT(IMGT_URL)
 
-# test_that("plotDbOverlap", {
-#     
-#     db <- data.frame(
-#         'sample_id' = c("s1","s1","s1","s2","s2","s2","s2"),
-#         'junction' = c("AAA","AAT","GTG","TAA","TTA","AAT","AAA"),
-#         'clone_id' = c(1,1,2,3,4,5,6)
-#     ) 
-# 
-#     
-#     overlap <- plotDbOverlap(db, group="sample_id", 
-#                              features=c("junction","clone_id"), 
-#                              identity=c("ham_nt","exact"), 
-#                              similarity=c("jaccard","jaccard"),
-#                              threshold=0)
-#  
-# })
+test_that("plotDbOverlap", {
+
+    db <- data.frame(
+        'sample_id' = c("s1","s1","s1","s2","s2","s2","s2"),
+        'junction' = c("AAA","AAT","GTG","TAA","TTA","AAT","AAA"),
+        'clone_id' = c(1,1,2,3,4,5,6)
+    )
+
+    # Two features: junction (ham_nt identity) and clone_id (exact identity).
+    overlap <- plotDbOverlap(db, group="sample_id",
+                             features=c("junction","clone_id"),
+                             identity=c("ham_nt","exact"),
+                             similarity=c("jaccard","jaccard"),
+                             threshold=0, silent=TRUE)
+
+    expect_s3_class(overlap$p, "ggplot")
+
+    expect_equal(as.character(overlap$perc$junction), c("s1","s2","s1","s2"))
+    expect_equal(as.character(overlap$perc$clone_id), c("s1","s1","s2","s2"))
+    # Diagonal (s1 vs s1, s2 vs s2) is not colored/compared against itself
+    expect_equal(overlap$perc$value, c(NA, 133.3, 0, NA))
+
+    expect_equal(as.character(overlap$note$value), c(NA, "4\n(133.3%)", "", NA))
+
+    # Single feature: clone_id only, no overlap between s1 (1,2) and s2 (3,4,5,6)
+    overlap <- plotDbOverlap(db, group="sample_id",
+                             features=c("clone_id"),
+                             identity=c("exact"),
+                             similarity=c("jaccard"),
+                             threshold=0, silent=TRUE)
+
+    expect_s3_class(overlap$p, "ggplot")
+
+    expect_equal(as.character(overlap$perc$clone_id.1), c("s1","s2","s1","s2"))
+    expect_equal(as.character(overlap$perc$clone_id.2), c("s1","s1","s2","s2"))
+    expect_equal(overlap$perc$value, c(NA, 0, 0, NA))
+    expect_equal(as.character(overlap$note$value), c(NA, "", "", NA))
+
+})
+
+test_that("clonal assignment example", {
+    # Uses the report's own bundled example data and default params
+    # (cloneby="subject_id", outputby="sample_id"), which splits the
+    # output into one file per sample_id.
+    skip_on_cran()
+    tmp_dir <- file.path(tempdir(),"clonal_assignment_example")
+    enchantr_report('clonal_assignment',
+                    report_params=list('outdir'=tmp_dir,
+                                       'nproc'=1,
+                                       'log'='test_clone_command_log'))
+    report_dir <- file.path(tmp_dir,"enchantr")
+    repertoires <- list.files(file.path(report_dir, "repertoires"), full.names = T)
+
+    for (fn in repertoires) {
+        # Load just the first 2 rows to check that the column exists
+        db <- read_rearrangement(fn, n_max=2)
+        expect_true("clone_id" %in% colnames(db))
+    }
+})
 
 test_that("clonal assignment 1:1", {
     # Input in one file, output in 1 file.
@@ -40,9 +83,16 @@ test_that("clonal assignment 1:1", {
     repertoires <- list.files(file.path(report_dir, "repertoires"), full.names = T)
     expect_equal(length(repertoires), 1)
     expect_equal(basename(repertoires), "FNA_clonal-assignment_clone-pass.tsv")
-    expect_warning(
-        db <- read_rearrangement(repertoires),
-        "rev_comp is not logical"
+    # Older airr versions warn that rev_comp is not logical; newer versions
+    # don't. Muffle the warning if it happens, but let any other (unexpected)
+    # warning propagate and fail the test.
+    db <- withCallingHandlers(
+        read_rearrangement(repertoires),
+        warning = function(w) {
+            if (grepl("rev_comp is not logical", conditionMessage(w))) {
+                invokeRestart("muffleWarning")
+            }
+        }
     )
     expect_equal(nrow(db), 1142)
 
@@ -188,3 +238,23 @@ test_that("clonal assignment 1:1", {
 #                                        "Subject_0_60_clonal-assignment_clone-pass.tsv"))
 #     expect_equal(nrow(db), 1427)  
 # })
+
+
+test_that("convergence example", {
+    # Uses the report's own bundled example data and default params
+    skip_on_cran()
+    tmp_dir <- file.path(tempdir(),"convergence_example")
+    enchantr_report('convergence',
+                    report_params=list('outdir'=tmp_dir,
+                                       'nproc'=1,
+                                       'log'='test_convergence_command_log'))
+    report_dir <- file.path(tmp_dir,"enchantr")
+    repertoires <- list.files(file.path(report_dir, "repertoires"), full.names = T)
+    expect_true(length(repertoires) > 0)
+
+    for (fn in repertoires) {
+        # Load just the first 2 rows to check that the column exists
+        db <- read_rearrangement(fn, n_max=2)
+        expect_true("convergent_cluster_id" %in% colnames(db))
+    }
+})


### PR DESCRIPTION
- Replace Box-hosted example input files with links to the example data files under `data-raw/` in this repo, across the clonal assignment, convergence, dowser lineage, and find_threshold report templates.
- Update the clonal assignment template's default `threshold` from `1` to `0.2` to match the new example data.
- Fix `plotDbOverlap()` so it no longer errors when `xlab`/`ylab` are identical (e.g. comparing a single feature against itself). The two columns are now suffixed `.1`/`.2` before renaming instead of colliding.
- Fix the convergence report so it no longer fails when `clone_id` is absent from the input: it now falls back to plotting `convergent_cluster_id` alone, and the UpSet plot step uses `select(-any_of("clone_id"))` instead of assuming the column exists.
- Re-enable and expand the `plotDbOverlap` unit tests (previously commented out), covering both the two-feature and single-feature (self-comparison) cases.
- Unit testing now runs the `clonal_assignment` and `convergence` reports with default example data and parameters.
- Make the `rev_comp` warning checks in `test_IO.R` and `test_clonal_assignment.R` tolerant of newer `airr` versions that no longer emit that warning, using `withCallingHandlers`/`invokeRestart("muffleWarning")` instead of `expect_warning`.