### PR TITLE
Force adding cell_id to collapsing groups in single cell data

### DIFF
--- a/R/collapse_duplicates.R
+++ b/R/collapse_duplicates.R
@@ -67,8 +67,16 @@ findDuplicates <- function (db,
         }
     }
 
+    cell_id <- NULL
+    if ("cell_id" %in% colnames(db)) {
+        if (any(!is.na(db[['cell_id']]))) {
+            cell_id <- "cell_id"
+            message("Single-cell data detected (cell_id column present): adding 'cell_id' to collapsing groups.")
+        }
+    }
+
     columns <- c(groups, id, seq, text_fields, num_fields, seq_fields,
-                "v_call", d_call, "j_call", "junction_length", c_call, "productive")
+                "v_call", d_call, "j_call", "junction_length", c_call, cell_id, "productive")
     columns <- columns[!is.null(columns)]
     check <- alakazam::checkColumns(db, columns)
     if (!check == TRUE ) { stop(check) }
@@ -80,7 +88,7 @@ findDuplicates <- function (db,
         mutate(v_gene=getGene(v_call),
                 d_gene=getGene(d_call),
                 j_gene=getGene(j_call)) %>%
-        group_by(!!!rlang::syms(c(groups, "v_gene", "j_gene", c_call, "junction_length", "productive", "seq_len"))) %>%
+        group_by(!!!rlang::syms(c(groups, "v_gene", "j_gene", c_call, cell_id, "junction_length", "productive", "seq_len"))) %>%
         group_indices()
 
     db_subset <- db %>%

--- a/tests/testthat/test_collapse_duplicates.R
+++ b/tests/testthat/test_collapse_duplicates.R
@@ -36,6 +36,29 @@ test_that("findDuplicates", {
   expect_equivalent(obs, exp)
 })
 
+test_that("findDuplicates respects cell_id in single-cell data", {
+  # Two records from different cells share the same sequence — they must NOT be collapsed.
+  # One additional record from cell2 has a unique sequence and should pass as-is.
+  db <- data.frame(
+    sequence_id        = c("cell1_contig1", "cell2_contig1", "cell2_contig2"),
+    sequence_alignment = c("CCCCTGGG",      "CCCCTGGG",      "ATCGGGGA"),
+    cell_id            = c("cell1",         "cell2",         "cell2"),
+    sample_id          = rep("S1", 3),
+    v_call             = rep("IGHV1", 3),
+    d_call             = rep("d_call", 3),
+    j_call             = rep("IGHJ2", 3),
+    junction_length    = rep(48, 3),
+    productive         = rep(TRUE, 3),
+    stringsAsFactors   = FALSE
+  )
+
+  obs <- findDuplicates(db, groups = "sample_id", num_fields = NULL)
+
+  # All three records should pass: identical sequences from different cells must be kept separate.
+  expect_true(all(obs$collapse_pass))
+  expect_equal(nrow(obs[obs$collapse_pass, ]), 3)
+})
+
 
 
 test_that("mask_5prime_sequence_alignment", {


### PR DESCRIPTION
For assembled single-cell input, records from different cells with the same sequence are being collapsed together if cell_id is not included in the collapsing groups. This is easy to miss. For better usability, detect if cell_id is present and single-cell mode is active, then add it to the groups. I think airrflow specifies cell_id, so maybe only relevant if the report used outside of airrflow.