### PR TITLE
Fix sample_id detection in file size report

### DIFF
--- a/R/file_size.R
+++ b/R/file_size.R
@@ -419,7 +419,17 @@ consoleLogsAsGraphs <- function(logs, metadata=NULL) {
             if (nrow(this_meta)==0) {
                 fasta_idx <- grepl("\\.fasta_[0-9]+$|\\.fasta$", V(g)$name[c_idx])
                 if (any(fasta_idx)) {
-                    v_sample_id <- sub("([^_]+)_.+","\\1", V(g)$name[c_idx][fasta_idx])
+                    fasta_names <- V(g)$name[c_idx][fasta_idx]
+                    known_ids <- unique(metadata$sample_id)
+                    # Match against known sample_ids and keep the longest
+                    # (most specific) match, so that a sample_id that is
+                    # itself a prefix of another (e.g. "HC1" vs "HC1_T1")
+                    # doesn't incorrectly shadow the correct, longer one.
+                    v_sample_id <- vapply(fasta_names, function(nm) {
+                        matches <- known_ids[startsWith(nm, paste0(known_ids, "_"))]
+                        if (length(matches) == 0) return(NA_character_)
+                        matches[which.max(nchar(matches))]
+                    }, character(1))
                     this_meta <- metadata[metadata$sample_id %in% v_sample_id,,drop=FALSE] %>%
                         select(-filename, -name) %>%
                         distinct()

--- a/R/file_size.R
+++ b/R/file_size.R
@@ -425,8 +425,18 @@ consoleLogsAsGraphs <- function(logs, metadata=NULL) {
                     # (most specific) match, so that a sample_id that is
                     # itself a prefix of another (e.g. "HC1" vs "HC1_T1")
                     # doesn't incorrectly shadow the correct, longer one.
+                    # A sample_id can appear in a fasta node name in two
+                    # ways: followed by "_" and additional filename parts (e.g.
+                    # "HC1_sequences.fasta_3978", produced by ConvertDb.py),
+                    # or as the entire stem (no "_", e.g.
+                    # "HC1.fasta_100", produced when nf-core/airrflow's
+                    # RENAME_FILE process renames a user-supplied fasta
+                    # to "<sample_id>.fasta"). Strip the trailing
+                    # ".fasta"/".fasta_<n>" to get that stem for the exact-
+                    # match check.
                     v_sample_id <- vapply(fasta_names, function(nm) {
-                        matches <- known_ids[startsWith(nm, paste0(known_ids, "_"))]
+                        stem <- sub("\\.fasta(_[0-9]+)?$", "", nm)
+                        matches <- known_ids[known_ids == stem | startsWith(nm, paste0(known_ids, "_"))]
                         if (length(matches) == 0) return(NA_character_)
                         matches[which.max(nchar(matches))]
                     }, character(1))

--- a/tests/testthat/test_file-size.R
+++ b/tests/testthat/test_file-size.R
@@ -135,8 +135,8 @@ test_that("consoleLogsAsGraphs assigns sample_id correctly when one sample_id is
     result <- consoleLogsAsGraphs(logs, metadata = metadata)
 
     g <- result$workflow
-    hc1_sample_id <- igraph::vertex_attr(g, "sample_id")[V(g)$name == "HC1_sequences.fasta_3978"]
-    hc1_t1_sample_id <- igraph::vertex_attr(g, "sample_id")[V(g)$name == "HC1_T1_sequences.fasta_2266"]
+    hc1_sample_id <- igraph::vertex_attr(g, "sample_id")[igraph::V(g)$name == "HC1_sequences.fasta_3978"]
+    hc1_t1_sample_id <- igraph::vertex_attr(g, "sample_id")[igraph::V(g)$name == "HC1_T1_sequences.fasta_2266"]
 
     expect_equal(hc1_sample_id, "HC1")
     expect_equal(hc1_t1_sample_id, "HC1_T1")

--- a/tests/testthat/test_file-size.R
+++ b/tests/testthat/test_file-size.R
@@ -142,3 +142,40 @@ test_that("consoleLogsAsGraphs assigns sample_id correctly when one sample_id is
     expect_equal(hc1_t1_sample_id, "HC1_T1")
     expect_equal(sort(names(result$by_sample)), c("HC1", "HC1_T1"))
 })
+
+test_that("consoleLogsAsGraphs assigns sample_id for a bare '<sample_id>.fasta' node", {
+    # nf-core/airrflow's RENAME_FILE process renames a user-provided fasta
+    # to "<sample_id>.fasta" (no "_" before the extension). Simulate
+    # components whose root is a bare fasta node, landing in the
+    # prefix-matching fallback with no "_" boundary to match on. Include
+    # both HC1 and HC1_T1 to also guard the prefix-collision case in this
+    # bare-filename form.
+    logs <- data.frame(
+        log_id      = c("log_1", "log_2", "log_3", "log_4"),
+        input       = c("HC1.fasta", "HC1_igblast.fmt7",
+                         "HC1_T1.fasta", "HC1_T1_igblast.fmt7"),
+        output      = c("HC1_igblast.fmt7", "HC1_db-pass.tsv",
+                         "HC1_T1_igblast.fmt7", "HC1_T1_db-pass.tsv"),
+        task        = c("AssignGenes-igblast", "MakeDB-igblast",
+                         "AssignGenes-igblast", "MakeDB-igblast"),
+        input_size  = c(100, 100, 100, 100),
+        output_size = c(100, 100, 100, 100),
+        stringsAsFactors = FALSE
+    )
+
+    metadata <- data.frame(
+        sample_id = c("HC1", "HC1_T1"),
+        filename  = c("raw/original_HC1.fasta", "raw/original_HC1_T1.fasta"),
+        stringsAsFactors = FALSE
+    )
+
+    result <- consoleLogsAsGraphs(logs, metadata = metadata)
+
+    g <- result$workflow
+    expect_true("sample_id" %in% igraph::vertex_attr_names(g))
+    hc1_sample_id <- igraph::vertex_attr(g, "sample_id")[igraph::V(g)$name == "HC1.fasta_100"]
+    hc1_t1_sample_id <- igraph::vertex_attr(g, "sample_id")[igraph::V(g)$name == "HC1_T1.fasta_100"]
+    expect_equal(hc1_sample_id, "HC1")
+    expect_equal(hc1_t1_sample_id, "HC1_T1")
+    expect_equal(sort(names(result$by_sample)), c("HC1", "HC1_T1"))
+})

--- a/tests/testthat/test_file-size.R
+++ b/tests/testthat/test_file-size.R
@@ -114,3 +114,31 @@ test_that("consoleLogsAsGraphs handles same filename+size at different pipeline 
     root_count <- sum(igraph::degree(result$workflow, mode = "in") == 0)
     expect_gte(root_count, 1)
 })
+
+test_that("consoleLogsAsGraphs assigns sample_id correctly when one sample_id is a prefix of another", {
+    logs <- data.frame(
+        log_id      = c("log_1", "log_2"),
+        input       = c("HC1_sequences.fasta", "HC1_T1_sequences.fasta"),
+        output      = c("HC1_igblast.fmt7", "HC1_T1_igblast.fmt7"),
+        task        = c("AssignGenes-igblast", "AssignGenes-igblast"),
+        input_size  = c(3978, 2266),
+        output_size = c(3978, 2266),
+        stringsAsFactors = FALSE
+    )
+
+    metadata <- data.frame(
+        sample_id = c("HC1", "HC1_T1"),
+        filename  = c("HC1_S1_L001_R1_001.fastq.gz", "HC1_T1_S1_L001_R1_001.fastq.gz"),
+        stringsAsFactors = FALSE
+    )
+
+    result <- consoleLogsAsGraphs(logs, metadata = metadata)
+
+    g <- result$workflow
+    hc1_sample_id <- igraph::vertex_attr(g, "sample_id")[V(g)$name == "HC1_sequences.fasta_3978"]
+    hc1_t1_sample_id <- igraph::vertex_attr(g, "sample_id")[V(g)$name == "HC1_T1_sequences.fasta_2266"]
+
+    expect_equal(hc1_sample_id, "HC1")
+    expect_equal(hc1_t1_sample_id, "HC1_T1")
+    expect_equal(sort(names(result$by_sample)), c("HC1", "HC1_T1"))
+})


### PR DESCRIPTION
consoleLogsAsGraphs() inferred sample_id from .fasta root filenames by truncating at the first underscore, so "HC1_T1_sequences.fasta" resolved to "HC1" instead of "HC1_T1". Match against the known sample_id values instead and keep the longest (most specific) match.